### PR TITLE
Some modification to the packed BVH that should use less memory/make …

### DIFF
--- a/chunky/src/java/se/llbit/math/MidpointBVH.java
+++ b/chunky/src/java/se/llbit/math/MidpointBVH.java
@@ -22,10 +22,7 @@ import se.llbit.chunky.main.Chunky;
 import se.llbit.log.Log;
 import se.llbit.math.primitive.Primitive;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.Stack;
+import java.util.*;
 
 import static se.llbit.math.BVH.SPLIT_LIMIT;
 
@@ -34,11 +31,13 @@ public class MidpointBVH extends BinaryBVH {
         BVH.factories.put("MIDPOINT", new BVH.ImplementationFactory() {
             @Override
             public BVH.BVHImplementation create(Collection<Entity> entities, Vector3 worldOffset) {
-                LinkedList<Primitive> primitives = new LinkedList<>();
+                List<Primitive> primitives = new ArrayList<>();
                 for (Entity entity : entities) {
                     primitives.addAll(entity.primitives(worldOffset));
                 }
-                return new MidpointBVH(primitives.toArray(new Primitive[0]));
+                Primitive[] allPrimitives = primitives.toArray(new Primitive[0]);
+                primitives = null; // Allow the collection to be garbage collected during construction when only the array is used
+                return new MidpointBVH(allPrimitives);
             }
 
             @Override

--- a/chunky/src/java/se/llbit/math/SahBVH.java
+++ b/chunky/src/java/se/llbit/math/SahBVH.java
@@ -32,11 +32,13 @@ public class SahBVH extends BinaryBVH {
         BVH.factories.put("SAH", new BVH.ImplementationFactory() {
             @Override
             public BVH.BVHImplementation create(Collection<Entity> entities, Vector3 worldOffset) {
-                LinkedList<Primitive> primitives = new LinkedList<>();
+                List<Primitive> primitives = new ArrayList<>();
                 for (Entity entity : entities) {
                     primitives.addAll(entity.primitives(worldOffset));
                 }
-                return new SahBVH(primitives.toArray(new Primitive[0]));
+                Primitive[] allPrimitives = primitives.toArray(new Primitive[0]);
+                primitives = null; // Allow the collection to be garbage collected during construction when only the array is used
+                return new SahBVH(allPrimitives);
             }
 
             @Override

--- a/chunky/src/java/se/llbit/math/SahMaBVH.java
+++ b/chunky/src/java/se/llbit/math/SahMaBVH.java
@@ -32,11 +32,13 @@ public class SahMaBVH extends BinaryBVH {
         BVH.factories.put("SAH_MA", new BVH.ImplementationFactory() {
             @Override
             public BVH.BVHImplementation create(Collection<Entity> entities, Vector3 worldOffset) {
-                LinkedList<Primitive> primitives = new LinkedList<>();
+                List<Primitive> primitives = new ArrayList<>();
                 for (Entity entity : entities) {
                     primitives.addAll(entity.primitives(worldOffset));
                 }
-                return new SahMaBVH(primitives.toArray(new Primitive[0]));
+                Primitive[] allPrimitives = primitives.toArray(new Primitive[0]);
+                primitives = null; // Allow the collection to be garbage collected during construction when only the array is used
+                return new SahMaBVH(allPrimitives);
             }
 
             @Override
@@ -49,6 +51,7 @@ public class SahMaBVH extends BinaryBVH {
     public SahMaBVH(Primitive[] primitives) {
         Node root = constructSAH_MA(primitives);
         pack(root);
+        System.out.printf("primitives: %d\n", primitives.length);
         Log.info("Built SAH_MA BVH with depth: " + this.depth);
     }
 


### PR DESCRIPTION
…it possible for the garbage collector to collect sooner

Hey, some modification that should (hopefully) improve things during construction (no change to the final result).
Use ArrayList instead of LinkedList because that's more memory efficient (and often faster).
Construct the array from the collection (ArrayList, previously LinkedList), and then stop referencing the collection so it can be garbage collected before the construction begins.
During construction, stop referencing subtrees when they have been converted to their packed version.