### PR TITLE
Flatten the primitive in the bvh

### DIFF
--- a/chunky/src/java/se/llbit/math/MidpointBVH.java
+++ b/chunky/src/java/se/llbit/math/MidpointBVH.java
@@ -49,7 +49,7 @@ public class MidpointBVH extends BinaryBVH {
 
     public MidpointBVH(Primitive[] primitives) {
         Node root = constructMidpointSplit(primitives);
-        pack(root);
+        pack(root, primitives.length);
         Log.info("Built MIDPOINT BVH with depth: " + this.depth);
     }
 

--- a/chunky/src/java/se/llbit/math/SahBVH.java
+++ b/chunky/src/java/se/llbit/math/SahBVH.java
@@ -50,7 +50,7 @@ public class SahBVH extends BinaryBVH {
 
     public SahBVH(Primitive[] primitives) {
         Node root = constructSAH(primitives);
-        pack(root);
+        pack(root, primitives.length);
         Log.info("Built SAH BVH with depth: " + this.depth);
     }
 

--- a/chunky/src/java/se/llbit/math/SahMaBVH.java
+++ b/chunky/src/java/se/llbit/math/SahMaBVH.java
@@ -50,7 +50,7 @@ public class SahMaBVH extends BinaryBVH {
 
     public SahMaBVH(Primitive[] primitives) {
         Node root = constructSAH_MA(primitives);
-        pack(root);
+        pack(root, primitives.length);
         System.out.printf("primitives: %d\n", primitives.length);
         Log.info("Built SAH_MA BVH with depth: " + this.depth);
     }


### PR DESCRIPTION
Another change that saves a bit of memory but this one might be more controversial, so you see if you want it or not.
Basically, it saves memory by flattening all the primitives into a single big array instead of having a lot of small ones. It saved around 5MB for one region (of greefield) with a bit under 300k primitives.
The big issue with this change is that it reduce the number of used to index the array from 31 to 28, limiting the number of primitives to 2^28. That's less than 1000 region of 300k primitives, and 1000 region isn't out of reach as Jack already did it (and I hope we can go further with all the changes we are doing)