### PR TITLE
Update default sun luminosity

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -120,7 +120,7 @@ public class Sun implements JsonSerializable {
 
   private double intensity = DEFAULT_INTENSITY;
 
-  private double luminosity = 100;
+  private double luminosity = 325;
   private double luminosityPdf = 1.0 / luminosity;
 
   private double azimuth = Math.PI / 2.5;


### PR DESCRIPTION
Changed the default sun luminosity from 100, which was too dim, to 325, to better match the default sun intensity of 1.25 when Fast sun sampling is used.

This is the default sun luminosity of 100, using Sun Sampling Strategy: None; it is not very bright.
![None_100-2048](https://user-images.githubusercontent.com/92183530/163697037-f5f956d7-d552-4948-b5f2-6dfd6d208368.png)

This is the default sun intensity of 1.25, using Sun Sampling Strategy: Fast; default brightness.
![Fast_1 25-129](https://user-images.githubusercontent.com/92183530/163697075-7a46a10c-4927-4710-a838-793b6ec54127.png)

And this is the sun luminosity raised to 325, using Sun Sampling Strategy: None (denoised); to better match the brightness of  sun intensity: 1.25 using Sun Sampling Strategy: Fast.
![None_325-4096 denoised](https://user-images.githubusercontent.com/92183530/163697114-f35850cc-383e-4f1d-b12e-e381a253295a.png)

